### PR TITLE
Bump tree-sitter-bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "tree-sitter-agda": "github:pokey/tree-sitter-agda#e5fba6cabe8c7fc7993ced2b86704f3841215284",
-    "tree-sitter-bash": "^0.20.3",
+    "tree-sitter-bash": "github:tree-sitter/tree-sitter-bash#7331995b19b8f8aba2d5e26deb51d2195c18bc94",
     "tree-sitter-c": "^0.19.0",
     "tree-sitter-c-sharp": "^0.19.0",
     "tree-sitter-cli": "^0.20.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "tree-sitter-agda": "github:pokey/tree-sitter-agda#e5fba6cabe8c7fc7993ced2b86704f3841215284",
-    "tree-sitter-bash": "^0.19.0",
+    "tree-sitter-bash": "^0.20.3",
     "tree-sitter-c": "^0.19.0",
     "tree-sitter-c-sharp": "^0.19.0",
     "tree-sitter-cli": "^0.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,9 +1879,9 @@ node-abi@^2.7.0:
     semver "^5.4.1"
 
 node-abi@^3.3.0:
-  version "3.52.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.52.0.tgz#ffba0a85f54e552547e5849015f40f9514d5ba7c"
-  integrity sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==
+  version "3.54.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.54.0.tgz#f6386f7548817acac6434c6cba02999c9aebcc69"
+  integrity sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==
   dependencies:
     semver "^7.3.5"
 
@@ -2687,12 +2687,11 @@ tr46@~0.0.3:
   dependencies:
     nan "^2.14.0"
 
-tree-sitter-bash@^0.20.3:
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/tree-sitter-bash/-/tree-sitter-bash-0.20.3.tgz#641415d93340cc7f920de10ae1836b1ce88ec14b"
-  integrity sha512-/CjVqWSCPJ05G8LgqNedxNY9FgRpZydFDXdO48c8wb0VCvKaZSGHwihlkyAcfFqpnI061aI2DAu6VuRnJPhoAg==
+"tree-sitter-bash@github:tree-sitter/tree-sitter-bash#7331995b19b8f8aba2d5e26deb51d2195c18bc94":
+  version "0.20.4"
+  resolved "https://codeload.github.com/tree-sitter/tree-sitter-bash/tar.gz/7331995b19b8f8aba2d5e26deb51d2195c18bc94"
   dependencies:
-    nan "^2.17.0"
+    nan "^2.18.0"
     prebuild-install "^7.1.1"
     web-tree-sitter "^0.20.8"
 
@@ -2757,7 +2756,7 @@ tree-sitter-css@^0.19.0:
   resolved "https://codeload.github.com/tree-sitter/tree-sitter-haskell/tar.gz/ca10c43a4c9bfe588c480d2941726c2fadcae699"
   dependencies:
     nan "^2.12.1"
-    node-gyp ">=7 <10"
+    node-gyp "^7.1.2"
 
 "tree-sitter-hcl@https://github.com/MichaHoffmann/tree-sitter-hcl#b5539065432c08e4118eb3ee7c94902fdda85708":
   version "0.2.0-snapshot"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,13 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
+node-abi@^3.3.0:
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.52.0.tgz#ffba0a85f54e552547e5849015f40f9514d5ba7c"
+  integrity sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==
+  dependencies:
+    semver "^7.3.5"
+
 node-abi@^3.45.0:
   version "3.51.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.51.0.tgz#970bf595ef5a26a271307f8a4befa02823d4e87d"
@@ -2168,7 +2175,7 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-prebuild-install@^5.0.0, prebuild-install@^5.3.3:
+prebuild-install@^5.0.0:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
   integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
@@ -2188,6 +2195,24 @@ prebuild-install@^5.0.0, prebuild-install@^5.3.3:
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
+
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -2447,6 +2472,15 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2653,13 +2687,14 @@ tr46@~0.0.3:
   dependencies:
     nan "^2.14.0"
 
-tree-sitter-bash@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/tree-sitter-bash/-/tree-sitter-bash-0.19.0.tgz#756332e3c5494a0b5ccda04c182e7206d65cf350"
-  integrity sha512-i/0NUZHSrxmYtQWMX+Tvuk9PBvsB0S3h0vD17qHSGuvPYgvpekRy8do75CAXyH6FlycMhejM39gNRppyvDeiVQ==
+tree-sitter-bash@^0.20.3:
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/tree-sitter-bash/-/tree-sitter-bash-0.20.3.tgz#641415d93340cc7f920de10ae1836b1ce88ec14b"
+  integrity sha512-/CjVqWSCPJ05G8LgqNedxNY9FgRpZydFDXdO48c8wb0VCvKaZSGHwihlkyAcfFqpnI061aI2DAu6VuRnJPhoAg==
   dependencies:
-    nan "^2.14.0"
-    prebuild-install "^5.3.3"
+    nan "^2.17.0"
+    prebuild-install "^7.1.1"
+    web-tree-sitter "^0.20.8"
 
 tree-sitter-c-sharp@^0.19.0:
   version "0.19.1"
@@ -2722,7 +2757,7 @@ tree-sitter-css@^0.19.0:
   resolved "https://codeload.github.com/tree-sitter/tree-sitter-haskell/tar.gz/ca10c43a4c9bfe588c480d2941726c2fadcae699"
   dependencies:
     nan "^2.12.1"
-    node-gyp "^7.1.2"
+    node-gyp ">=7 <10"
 
 "tree-sitter-hcl@https://github.com/MichaHoffmann/tree-sitter-hcl#b5539065432c08e4118eb3ee7c94902fdda85708":
   version "0.2.0-snapshot"
@@ -2985,7 +3020,7 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-"web-tree-sitter@file:vendor/web-tree-sitter":
+web-tree-sitter@^0.20.8, "web-tree-sitter@file:vendor/web-tree-sitter":
   version "0.20.8"
 
 webidl-conversions@^3.0.0:


### PR DESCRIPTION
I ran into a few bugs while working on next gen scope support for shellscript in cursorless, some of which are fixed in the updated tree-sitter-bash, so bumping. 

I bumped it by re-running `yarn add -D tree-sitter-bash` rather than referencing the latest commit from git. 

Tested the new .vsix against my shellscript.scm and confirmed it fixes some of the issues I've run into.