### PR TITLE
Fix hcl url

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "tree-sitter-elixir": "github:elixir-lang/tree-sitter-elixir#b20eaa75565243c50be5e35e253d8beb58f45d56",
     "tree-sitter-go": "github:tree-sitter/tree-sitter-go#bbaa67a180cfe0c943e50c55130918be8efb20bd",
     "tree-sitter-haskell": "github:tree-sitter/tree-sitter-haskell#ca10c43a4c9bfe588c480d2941726c2fadcae699",
-    "tree-sitter-hcl": "https://github.com/MichaHoffmann/tree-sitter-hcl#b5539065432c08e4118eb3ee7c94902fdda85708",
+    "tree-sitter-hcl": "github:MichaHoffmann/tree-sitter-hcl#e135399cb31b95fac0760b094556d1d5ce84acf0",
     "tree-sitter-html": "^0.19.0",
     "tree-sitter-java": "github:tree-sitter/tree-sitter-java#ac14b4b1884102839455d32543ab6d53ae089ab7",
     "tree-sitter-javascript": "github:tree-sitter/tree-sitter-javascript#5720b249490b3c17245ba772f6be4a43edb4e3b7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,9 +2758,9 @@ tree-sitter-css@^0.19.0:
     nan "^2.12.1"
     node-gyp "^7.1.2"
 
-"tree-sitter-hcl@https://github.com/MichaHoffmann/tree-sitter-hcl#b5539065432c08e4118eb3ee7c94902fdda85708":
+"tree-sitter-hcl@github:MichaHoffmann/tree-sitter-hcl#e135399cb31b95fac0760b094556d1d5ce84acf0":
   version "0.2.0-snapshot"
-  resolved "https://github.com/MichaHoffmann/tree-sitter-hcl#b5539065432c08e4118eb3ee7c94902fdda85708"
+  resolved "https://codeload.github.com/MichaHoffmann/tree-sitter-hcl/tar.gz/e135399cb31b95fac0760b094556d1d5ce84acf0"
   dependencies:
     nan "^2.14.2"
     tree-sitter-cli "^0.20.6"


### PR DESCRIPTION
The tree-sitter-hcl url was using `https://github.com/MichaHoffmann/tree-sitter-hcl#` instead of `github:MichaHoffmann/tree-sitter-hcl#`, the latter style being what all of the other dependencies use. Seems like yarn2nix helper functions can't handle the https:// style github url properly, which prevents building using nix. So this just changes the URI format.