### PR TITLE
Add gdscript support (upgrade tree-sitter-wasms to 0.4.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "parse-tree",
   "displayName": "Parse tree",
   "description": "Access document syntax using tree-sitter",
-  "version": "0.37.2",
+  "version": "0.38.0",
   "publisher": "pokey",
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "onLanguage:dart",
     "onLanguage:elixir",
     "onLanguage:elm",
+    "onLanguage:gdscript",
     "onLanguage:gleam",
     "onLanguage:go",
     "onLanguage:haskell",
@@ -87,7 +88,7 @@
     "publish": "vsce publish patch"
   },
   "devDependencies": {
-    "@cursorless/tree-sitter-wasms": "0.3.0",
+    "@cursorless/tree-sitter-wasms": "0.4.0",
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
     "@types/vscode": "~1.58.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "parse-tree",
   "displayName": "Parse tree",
   "description": "Access document syntax using tree-sitter",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "publisher": "pokey",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,7 @@ export async function activate(context: vscode.ExtensionContext) {
       absolute = path.join(
         context.extensionPath,
         "parsers",
+        "out",                    // bafflingly, upgrading the vscode-parse-tree dep to 0.4.0 causes the parsers to be placed in a different location???
         language.module + ".wasm"
       );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ const languages: {
   dart: { module: "tree-sitter-dart" },
   elm: { module: "tree-sitter-elm" },
   elixir: { module: "tree-sitter-elixir" },
+  gdscript: {module: "tree-sitter-gdscript"},
   gleam: { module: "tree-sitter-gleam" },
   go: { module: "tree-sitter-go" },
   haskell: { module: "tree-sitter-haskell" },


### PR DESCRIPTION
Strangely also requires a change to where `extension.ts` looks for the parser `.wasm`s—not sure if this is due to the major architecture change in https://github.com/cursorless-dev/tree-sitter-wasms a while back, or something else... assuming that can be fixed with a 0.4.1 or something, then that change can be reverted. 