### PR TITLE
Add language id properties as an alias for java-properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parse-tree",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parse-tree",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
         "semver": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "parse-tree",
   "displayName": "Parse tree",
   "description": "Access document syntax using tree-sitter",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "publisher": "pokey",
   "repository": {
     "type": "git",
@@ -51,6 +51,7 @@
     "onLanguage:nix",
     "onLanguage:perl",
     "onLanguage:php",
+    "onLanguage:properties",
     "onLanguage:python",
     "onLanguage:r",
     "onLanguage:ruby",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ const languages: Record<string, Language | undefined> = {
   nix: { module: "tree-sitter-nix" },
   perl: { module: "tree-sitter-perl" },
   php: { module: "tree-sitter-php" },
+  properties: { module: "tree-sitter-properties" },
   python: { module: "tree-sitter-python" },
   r: { module: "tree-sitter-r" },
   ruby: { module: "tree-sitter-ruby" },


### PR DESCRIPTION
These files can apparently be recognized as either `properties` or `java-properties`